### PR TITLE
gitignore .vs directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ obj/
 [Rr]elease*/
 _ReSharper*/
 [Tt]est[Rr]esult*
+.vs/


### PR DESCRIPTION
Newer versions of VS create a ` .vs` directory that should be ignored.