### PR TITLE
add .EditorConfig file

### DIFF
--- a/.EditorConfig
+++ b/.EditorConfig
@@ -1,0 +1,6 @@
+[*.cs]
+end_of_line = lf
+insert_final_newline = true
+indent_style = space
+indent_size = 4
+charset = utf-8

--- a/Go.sln
+++ b/Go.sln
@@ -9,6 +9,7 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GoTestProject", "GoTestProj
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{0125E950-A2EE-4CD7-87E8-42CF7E1CD0CB}"
 	ProjectSection(SolutionItems) = preProject
+		.EditorConfig = .EditorConfig
 		Go.vsmdi = Go.vsmdi
 		Local.testsettings = Local.testsettings
 		TraceAndTestImpact.testsettings = TraceAndTestImpact.testsettings


### PR DESCRIPTION
Helps with keeping whitespace consistent in VS17.

(Not saying I'm happy with spaces for indentation ;)
